### PR TITLE
Removing the C++ IO as part of the 'sutf' tool

### DIFF
--- a/include/simdutf.h
+++ b/include/simdutf.h
@@ -1,8 +1,7 @@
 #ifndef SIMDUTF_H
 #define SIMDUTF_H
-#include <string>
 #include <cstring>
-#include <vector>
+
 
 #include "simdutf/compiler_check.h"
 #include "simdutf/common_defs.h"

--- a/include/simdutf/encoding_types.h
+++ b/include/simdutf/encoding_types.h
@@ -1,3 +1,5 @@
+#include <string>
+
 namespace simdutf {
 
 enum encoding_type {

--- a/include/simdutf/encoding_types.h
+++ b/include/simdutf/encoding_types.h
@@ -1,5 +1,3 @@
-#include <string>
-
 namespace simdutf {
 
 enum encoding_type {
@@ -17,7 +15,7 @@ enum endianness {
         BIG
 };
 
-std::string to_string(encoding_type bom);
+//std::string to_string(encoding_type bom);
 
 // Note that BOM for UTF8 is discouraged.
 namespace BOM {

--- a/include/simdutf/encoding_types.h
+++ b/include/simdutf/encoding_types.h
@@ -15,7 +15,7 @@ enum endianness {
         BIG
 };
 
-//std::string to_string(encoding_type bom);
+std::string to_string(encoding_type bom);
 
 // Note that BOM for UTF8 is discouraged.
 namespace BOM {

--- a/src/generic/utf16.h
+++ b/src/generic/utf16.h
@@ -1,5 +1,4 @@
 #include "scalar/utf16.h"
-#include <iostream>
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 add_executable(sutf sutf.cpp)
 target_link_libraries(sutf PUBLIC simdutf)
 
-if(NOT(MSVC) AND NOT(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
   target_link_options(sutf PRIVATE "-static-libstdc++")
 endif()
 

--- a/tools/sutf.cpp
+++ b/tools/sutf.cpp
@@ -4,10 +4,11 @@
 #include <string>
 #include <set>
 #include <filesystem>
-#include <iostream>
-#include <ostream>
+//#include <iostream>
+//#include <ostream>
 #include <iterator>
-#include <fstream>
+//#include <fstream>
+#include <climits>
 
 CommandLine parse_and_validate_arguments(int argc, char* argv[]) {
   CommandLine cmdline;
@@ -68,43 +69,52 @@ CommandLine parse_and_validate_arguments(int argc, char* argv[]) {
 }
 
 void CommandLine::run() {
+  
+  //// Disable CRT_SECURE warning on MSVC: manually verified this is safe
+  //std::FILE *fp = std::fopen(path.string().c_str(), "wb");
+  //SIMDUTF_POP_DISABLE_WARNINGS
   if (output_file.empty()) {
-    run_procedure(&std::cout);
+    //fileno(stdout);
+    run_procedure(stdout);
   } else {
-    std::ofstream output(output_file, std::ios::binary | std::ios::trunc);
-    run_procedure(&output);
-    output.close();
+    SIMDUTF_DISABLE_DEPRECATED_WARNING 
+    std::FILE *fp = std::fopen(output_file.string().c_str(), "wb");
+    SIMDUTF_POP_DISABLE_WARNINGS
+    //std::ofstream output(output_file, std::ios::binary | std::ios::trunc);
+    run_procedure(fp);
+    //output.close();
+    fclose(fp);
   }
 }
 
-void CommandLine::run_procedure(std::ostream* output) {
+void CommandLine::run_procedure(std::FILE *fpout) {
   if (from_encoding == "UTF-8") {
     if (to_encoding == "UTF-16LE" || to_encoding == "UTF-16") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str()); continue; }
         const char* data = reinterpret_cast<const char*>(input_data.data());
         const size_t size = input_data.size();
         std::vector<char16_t> output_buffer(size);
         size_t len = simdutf::convert_utf8_to_utf16le(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char16_t));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char16_t));
       }
     } else if (to_encoding == "UTF-16BE") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char* data = reinterpret_cast<const char*>(input_data.data());
         size_t size = input_data.size();
         std::vector<char16_t> output_buffer(size);
         size_t len = simdutf::convert_utf8_to_utf16be(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char16_t));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char16_t));
       }
     } else if (to_encoding == "UTF-32LE") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char* data = reinterpret_cast<const char*>(input_data.data());
         size_t size = input_data.size();
         std::vector<char32_t> output_buffer(size);
         size_t len = simdutf::convert_utf8_to_utf32(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char32_t));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char32_t));
       }
     } else {
       iconv_fallback();
@@ -113,62 +123,62 @@ void CommandLine::run_procedure(std::ostream* output) {
   else if (from_encoding == "UTF-16LE" || to_encoding == "UTF-16") {
     if (to_encoding == "UTF-8") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char16_t* data = reinterpret_cast<const char16_t*>(input_data.data());
         const size_t size = input_data.size() / 2;
         std::vector<char> output_buffer(2*size);
         size_t len = simdutf::convert_utf16le_to_utf8(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char));
       }
     } else if (to_encoding == "UTF-16BE") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char16_t* data = reinterpret_cast<const char16_t*>(input_data.data());
         const size_t size = input_data.size() / 2;
         std::vector<char16_t> output_buffer(size);
         simdutf::change_endianness_utf16(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), size);
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), size);
       }
     } else if (to_encoding == "UTF-32LE") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char16_t* data = reinterpret_cast<const char16_t*>(input_data.data());
         const size_t size = input_data.size() / 2;
         std::vector<char32_t> output_buffer(size);
         size_t len = simdutf::convert_utf16le_to_utf32(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char32_t));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char32_t));
       }
     } else {
-      std::cout << "UNSUPPORTED" << std::endl;
+      printf("UNSUPPORTED");
     }
   }
   else if (from_encoding == "UTF-16BE") {
     if (to_encoding == "UTF-8") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char16_t* data = reinterpret_cast<const char16_t*>(input_data.data());
         const size_t size = input_data.size() / 2;
         std::vector<char> output_buffer(2*size);
         size_t len = simdutf::convert_utf16be_to_utf8(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char));
       }
     } else if (to_encoding == "UTF-16LE" || to_encoding == "UTF-16") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char16_t* data = reinterpret_cast<const char16_t*>(input_data.data());
         const size_t size = input_data.size() / 2;
         std::vector<char16_t> output_buffer(size);
         simdutf::change_endianness_utf16(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), size);
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), size);
       }
     } else if (to_encoding == "UTF-32LE") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char16_t* data = reinterpret_cast<const char16_t*>(input_data.data());
         const size_t size = input_data.size() / 2;
         std::vector<char32_t> output_buffer(size);
         size_t len = simdutf::convert_utf16be_to_utf32(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char32_t));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char32_t));
       }
     } else {
       iconv_fallback();
@@ -177,30 +187,30 @@ void CommandLine::run_procedure(std::ostream* output) {
   else if (from_encoding == "UTF-32LE") {
     if (to_encoding == "UTF-8") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char32_t* data = reinterpret_cast<const char32_t*>(input_data.data());
         const size_t size = input_data.size() / 4;
         std::vector<char> output_buffer(4*size);
         size_t len = simdutf::convert_utf32_to_utf8(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char));
       }
     } else if (to_encoding == "UTF-16LE" || to_encoding == "UTF-16") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char32_t* data = reinterpret_cast<const char32_t*>(input_data.data());
         const size_t size = input_data.size() / 4;
         std::vector<char16_t> output_buffer(2*size);
         size_t len = simdutf::convert_utf32_to_utf16le(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char16_t));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char16_t));
       }
     } else if (to_encoding == "UTF-16BE") {
       for (auto file : input_files) {
-        load_file(file);
+        if(!load_file(file)) { printf("Could not load %s\n", file.c_str());  continue; }
         const char32_t* data = reinterpret_cast<const char32_t*>(input_data.data());
         const size_t size = input_data.size() / 4;
         std::vector<char16_t> output_buffer(2*size);
         size_t len = simdutf::convert_utf32_to_utf16be(data, size, output_buffer.data());
-        output->write(reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char16_t));
+        write_file(fpout, reinterpret_cast<char *>(output_buffer.data()), len * sizeof(char16_t));
       }
     } else {
       iconv_fallback();
@@ -227,13 +237,62 @@ void CommandLine::iconv_fallback() {
   }
 }
 
-void CommandLine::load_file(const std::filesystem::path& path) {
-  std::ifstream file;
-  file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-  file.open(path);
 
-  input_data.assign(std::istreambuf_iterator<char>(file),
-                    std::istreambuf_iterator<char>());
+bool CommandLine::write_file(std::FILE *fp, const char * data, size_t length) {
+
+  //SIMDUTF_DISABLE_DEPRECATED_WARNING // Disable CRT_SECURE warning on MSVC: manually verified this is safe
+  //std::FILE *fp = std::fopen(path.string().c_str(), "wb");
+  //SIMDUTF_POP_DISABLE_WARNINGS
+  if(fp == NULL) {
+    return false;
+  }
+  size_t bytes_written = std::fwrite(data, 1, length, fp);
+  if (bytes_written != length) {
+    return false;
+  }
+  return true;
+}
+
+bool CommandLine::load_file(const std::filesystem::path& path) {
+
+  SIMDUTF_DISABLE_DEPRECATED_WARNING // Disable CRT_SECURE warning on MSVC: manually verified this is safe
+  std::FILE *fp = std::fopen(path.string().c_str(), "rb");
+  SIMDUTF_POP_DISABLE_WARNINGS
+
+  if (fp == nullptr) {
+    return false;
+  }
+
+  // Get the file size
+  if(std::fseek(fp, 0, SEEK_END) < 0) {
+    std::fclose(fp);
+    return false;
+  }
+#if defined(SIMDUTF_VISUAL_STUDIO) && !SIMDUTF_IS_32BITS
+  __int64 file_size_in_bytes = _ftelli64(fp);
+  if(file_size_in_bytes == -1L) {
+    std::fclose(fp);
+    return false;
+  }
+#else
+  long file_size_in_bytes = std::ftell(fp);
+  if((file_size_in_bytes < 0) || (file_size_in_bytes == LONG_MAX)) {
+    std::fclose(fp);
+    return false;
+  }
+#endif
+
+  // Allocate the memory
+  size_t length = static_cast<size_t>(file_size_in_bytes);
+  input_data.resize(static_cast<size_t>(length));
+
+  // Read the padded_string
+  std::rewind(fp);
+  size_t bytes_read = std::fread(input_data.data(), 1, length, fp);
+  if (std::fclose(fp) != 0 || bytes_read != length) {
+    return false;
+  }
+  return true;
 }
 
 void CommandLine::show_help() {

--- a/tools/sutf.cpp
+++ b/tools/sutf.cpp
@@ -4,10 +4,7 @@
 #include <string>
 #include <set>
 #include <filesystem>
-//#include <iostream>
-//#include <ostream>
 #include <iterator>
-//#include <fstream>
 #include <climits>
 
 CommandLine parse_and_validate_arguments(int argc, char* argv[]) {

--- a/tools/sutf.h
+++ b/tools/sutf.h
@@ -3,7 +3,6 @@
 #include <filesystem>
 #include <vector>
 #include <set>
-//#include <ostream>
 
 
 class CommandLine
@@ -24,5 +23,5 @@ public:
   void run_procedure(std::FILE *fp);
   void iconv_fallback();
   bool load_file(const std::filesystem::path&);
-  bool write_file(std::FILE *fp, const char * data, size_t length);
+  bool write_to_file_descriptor(std::FILE *fp, const char * data, size_t length);
 };

--- a/tools/sutf.h
+++ b/tools/sutf.h
@@ -3,7 +3,7 @@
 #include <filesystem>
 #include <vector>
 #include <set>
-#include <ostream>
+//#include <ostream>
 
 
 class CommandLine
@@ -21,7 +21,8 @@ public:
   static void show_formats();
 
   void run();
-  void run_procedure(std::ostream*);
+  void run_procedure(std::FILE *fp);
   void iconv_fallback();
-  void load_file(const std::filesystem::path&);
+  bool load_file(const std::filesystem::path&);
+  bool write_file(std::FILE *fp, const char * data, size_t length);
 };


### PR DESCRIPTION
With this change, using an AWS graviton box, we beat iconv with sutf...

```
> cmake -B build && cmake --build build --target sutf && hyperfine './build/tools/sutf -f UTF-8 -t UTF-16 unicode_lipsum/lipsum/Japanese-Lipsum.utf8.txt -o  /dev/null' && hyperfine 'iconv -f UTF-8 -t UTF-16 unicode_lipsum/lipsum/Japanese-Lipsum.utf8.txt -o  /dev/null'

Benchmark 1: ./build/tools/sutf -f UTF-8 -t UTF-16 unicode_lipsum/lipsum/Japanese-Lipsum.utf8.txt -o  /dev/null
  Time (mean ± σ):       0.9 ms ±   0.1 ms    [User: 0.7 ms, System: 0.2 ms]
  Range (min … max):     0.8 ms …   1.4 ms    1448 runs
 
  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: The first benchmarking run for this command was significantly slower than the rest (1.4 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.
 
Benchmark 1: iconv -f UTF-8 -t UTF-16 unicode_lipsum/lipsum/Japanese-Lipsum.utf8.txt -o  /dev/null
  Time (mean ± σ):       1.1 ms ±   0.3 ms    [User: 0.8 ms, System: 0.3 ms]
  Range (min … max):     0.9 ms …   9.5 ms    1472 runs
 
  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
```

And so forth...

```
Benchmark 1: ./build/tools/sutf -f UTF-8 -t UTF-16 unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt -o  /dev/null
  Time (mean ± σ):       0.9 ms ±   0.4 ms    [User: 0.7 ms, System: 0.2 ms]
  Range (min … max):     0.8 ms …  12.4 ms    1659 runs
 
  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 1: iconv -f UTF-8 -t UTF-16 unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt -o  /dev/null
  Time (mean ± σ):       1.1 ms ±   0.1 ms    [User: 0.9 ms, System: 0.3 ms]
  Range (min … max):     1.0 ms …   1.7 ms    1534 runs
```

All I do is remove the C++ IO stuff (iostream). My code is pretty dumb.

Please run your own benchmarks and assess.